### PR TITLE
Fix for redrawing in terminal vim, don't show useless items in quick fix list

### DIFF
--- a/plugin/jshint.vim
+++ b/plugin/jshint.vim
@@ -51,7 +51,6 @@ function! s:JSHint(cmd, args)
     " no error, sweet!
     cclose
     redraw!
-    echo "JSHint ..."
     echo "JSHint: Lint Free"
 
   end

--- a/plugin/jshint.vim
+++ b/plugin/jshint.vim
@@ -24,7 +24,7 @@ function! s:JSHint(cmd, args)
   let grepformat_bak=&grepformat
   try
     let &grepprg=g:jshintprg
-    let &grepformat="%f: line %l\\,\ col %c\\, %m"
+    let &grepformat="%f: line %l\\,\ col %c\\, %m,%-G"
     silent execute a:cmd . " " . l:fileargs
   finally
     let &grepprg=grepprg_bak

--- a/plugin/jshint.vim
+++ b/plugin/jshint.vim
@@ -13,8 +13,6 @@ endif
 
 function! s:JSHint(cmd, args)
   redraw
-  echo "JSHint ..."
-
   " If no file is provided, use current file
   if empty(a:args)
       let l:fileargs = expand("%")
@@ -48,7 +46,6 @@ function! s:JSHint(cmd, args)
     exec "nnoremap <silent> <buffer> go <CR><C-W><C-W>"
 
     redraw!
-
   else
 
     " no error, sweet!

--- a/plugin/jshint.vim
+++ b/plugin/jshint.vim
@@ -24,14 +24,14 @@ function! s:JSHint(cmd, args)
   let grepformat_bak=&grepformat
   try
     let &grepprg=g:jshintprg
-    let &grepformat="%f: line %l\\,\ col %c\\, %m,%-G"
+    let &grepformat="%f: line %l\\,\ col %c\\, %m,%-G,%-G%s error,%-G%s errors"
     silent execute a:cmd . " " . l:fileargs
   finally
     let &grepprg=grepprg_bak
     let &grepformat=grepformat_bak
   endtry
 
-  if len(getqflist()) > 1
+  if len(getqflist()) > 0
 
     " has errors display quickfix win
     botright copen

--- a/plugin/jshint.vim
+++ b/plugin/jshint.vim
@@ -15,20 +15,20 @@ function! s:JSHint(cmd, args)
   redraw
   " If no file is provided, use current file
   if empty(a:args)
-      let l:fileargs = expand("%")
+    let l:fileargs = expand("%")
   else
-      let l:fileargs = a:args
+    let l:fileargs = a:args
   end
 
   let grepprg_bak=&grepprg
   let grepformat_bak=&grepformat
   try
-      let &grepprg=g:jshintprg
-      let &grepformat="%f: line %l\\,\ col %c\\, %m"
-      silent execute a:cmd . " " . l:fileargs
+    let &grepprg=g:jshintprg
+    let &grepformat="%f: line %l\\,\ col %c\\, %m"
+    silent execute a:cmd . " " . l:fileargs
   finally
-      let &grepprg=grepprg_bak
-      let &grepformat=grepformat_bak
+    let &grepprg=grepprg_bak
+    let &grepformat=grepformat_bak
   endtry
 
   if len(getqflist()) > 1

--- a/plugin/jshint.vim
+++ b/plugin/jshint.vim
@@ -8,57 +8,55 @@
 
 " Location of jshint utility, change in vimrc i different
 if !exists("g:jshintprg")
-	let g:jshintprg="jshint"
+  let g:jshintprg="jshint"
 endif
 
 function! s:JSHint(cmd, args)
+  redraw
+  echo "JSHint ..."
+
+  " If no file is provided, use current file
+  if empty(a:args)
+      let l:fileargs = expand("%")
+  else
+      let l:fileargs = a:args
+  end
+
+  let grepprg_bak=&grepprg
+  let grepformat_bak=&grepformat
+  try
+      let &grepprg=g:jshintprg
+      let &grepformat="%f: line %l\\,\ col %c\\, %m"
+      silent execute a:cmd . " " . l:fileargs
+  finally
+      let &grepprg=grepprg_bak
+      let &grepformat=grepformat_bak
+  endtry
+
+  if len(getqflist()) > 1
+
+    " has errors display quickfix win
+    botright copen
+
+    " close quickfix
+    exec "nnoremap <silent> <buffer> q :ccl<CR>"
+
+    " open in a new window
+    exec "nnoremap <silent> <buffer> o <C-W><CR>"
+
+    " preview
+    exec "nnoremap <silent> <buffer> go <CR><C-W><C-W>"
+
+    redraw!
+
+  else
+
+    " no error, sweet!
+    cclose
     redraw
-    echo "JSHint ..."
+    echo "JSHint: Lint free"
 
-    " If no file is provided, use current file 
-    if empty(a:args)
-        let l:fileargs = expand("%")
-    else
-        let l:fileargs = a:args
-    end
-
-    let grepprg_bak=&grepprg
-    let grepformat_bak=&grepformat
-    try
-        let &grepprg=g:jshintprg
-        let &grepformat="%f: line %l\\,\ col %c\\, %m"
-        silent execute a:cmd . " " . l:fileargs
-    finally
-        let &grepprg=grepprg_bak
-        let &grepformat=grepformat_bak
-    endtry
-
-    if len(getqflist()) > 1
-
-      " has errors display quickfix win
-      botright copen
-
-      " close quickfix
-      exec "nnoremap <silent> <buffer> q :ccl<CR>"
-
-      " open in a new window 
-      exec "nnoremap <silent> <buffer> o <C-W><CR>"
-
-      " preview
-      exec "nnoremap <silent> <buffer> go <CR><C-W><C-W>"
-
-      redraw!
-
-    else
-
-      " no error, sweet!
-      cclose
-      redraw
-      echo "JSHint: Lint free"
-
-    end
-    
-
+  end
 endfunction
 
 command! -bang -nargs=* -complete=file JSHint call s:JSHint('grep<bang>',<q-args>)

--- a/plugin/jshint.vim
+++ b/plugin/jshint.vim
@@ -53,8 +53,9 @@ function! s:JSHint(cmd, args)
 
     " no error, sweet!
     cclose
-    redraw
-    echo "JSHint: Lint free"
+    redraw!
+    echo "JSHint ..."
+    echo "JSHint: Lint Free"
 
   end
 endfunction


### PR DESCRIPTION
- When you run jshint in terminal vim and there aren't any issues the screen is blanked forcing you to manually run redraw. This has been fixed by calling redraw! instead of just redraw.
- Don't show empty line or the number of errors in the quick fix list.
- Some general cleanup.
- Fixes have been tested in terminal vim (iterm2) and gui vim (macvim).
